### PR TITLE
Add install instructions for Mac OSX

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,11 @@ much difficulty to most other Unix-like operating systems.
 
    On Max OSX, use the Macintosh installer which can be downloaded from https://nodejs.org/download/. This will install both node and npm.
 
+   On Terminal, run:
+
+        $ sudo npm install npm -g
+        $ sudo np
+
 3. Install PostgreSQL, at least version 9.2 (to support `JSON` column type).
 
         $ sudo apt-get install postgresql-9.4  # for example
@@ -25,6 +30,15 @@ much difficulty to most other Unix-like operating systems.
    installed, which in turn can lead to mysterious errors in the
    coming import step.  If you encounter such errors, see the
    appropriate part of the "Troubleshooting" section later on.)
+
+   Install PostgreSQL on Mac OS X via Brew (http://exponential.io/blog/2015/02/21/install-postgresql-on-mac-os-x-via-brew/)
+
+        $ brew update
+        $ brew install postgres
+        $ postgres -D /usr/local/var/postgres
+        $ created `whoami`                      (back ticks, not single quotes)
+        $ psql
+
 
 4. PostgreSQL probably created a `postgres` user, but if it didn't, add one:
 
@@ -46,6 +60,8 @@ much difficulty to most other Unix-like operating systems.
         of the existing top-level environments listed in `config.json`
         or set up a whole new environment, e.g., "demo" (e.g., based
         on the "test" example).
+
+        If you don't know to set up a database username / password, it will be explained in step 7.
 
   * Do `cp config/recipients.sql.tmpl config/recipients.sql`, then edit the latter.
 


### PR DESCRIPTION
Add instructions on how to install node from Terminal in step 2. Include a link and instructions on how to install PostgreSQL for MAC OSX in step 3. This change will help Mac users go through the install process more smoothly.