### PR TITLE
Remove unused field & drop column #111

### DIFF
--- a/migrations/20151210-drop-column.sql
+++ b/migrations/20151210-drop-column.sql
@@ -1,0 +1,3 @@
+-- dropping the unused field 
+
+ALTER TABLE "Requests" DROP COLUMN "permission_to_text";

--- a/models/request.js
+++ b/models/request.js
@@ -26,7 +26,6 @@ module.exports = function(sequelize, DataTypes) {
 	zip: DataTypes.TEXT,
 	phone: DataTypes.TEXT,
 	email: DataTypes.TEXT,
-        permission_to_text: DataTypes.BOOLEAN,
         serial: { type: DataTypes.TEXT, unique: true }
     })
 }


### PR DESCRIPTION
I removed the 'permission_to_text' field from Request table in request.js file and also added a new migration to drop the unused column. 