### PR TITLE
All required fields must be filled before submitting form #145

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -135,7 +135,8 @@ block content
     script(type="text/javascript").
       function setLocale(locale) { document.cookie= "locale=" + locale; location.reload(); }
       var locale = /locale=([^;]+)/.exec(document.cookie);
-      if (locale[1]) {
+
+      if (locale && locale[1]) {
         $("select#language-switcher").val(locale[1]);
       }
       $("select#state").addClass('state-not-yet-selected');
@@ -143,6 +144,7 @@ block content
         $(this).children('option[value="state-not-yet-selected"]').remove();
         $(this).removeClass('state-not-yet-selected');
       });
+      
       $(".form-horizontal").validationEngine({
         'scroll': false,
         'autoPositionUpdate': true,


### PR DESCRIPTION
Tooltips will now work and the form will only succeed if all the
required fields are filled without having to change the language of
the page. The issue was that when the homepage loads, a variable
did not exist and it caused everything after it to break. I fixed this
issue by editing the conditional.