### PR TITLE
refactor language toggle to pull JS logic out of view

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,0 +1,34 @@
+var requestSmokeAlarm = function() {
+	var setLocale = function(locale) {
+		document.cookie = "locale=" + locale;
+		location.reload(); 
+	};
+
+	var initForm = function() {
+		var $stateDropdown = $('#state'),
+			locale = jQuery.cookie('locale');
+
+		$stateDropdown.addClass('state-not-yet-selected');
+		// bind focus event for dropdown
+		$stateDropdown.on('focus', function() {
+			$(this).children('option[value="state-not-yet-selected"]').remove();
+			$(this).removeClass('state-not-yet-selected');
+		});
+	};
+
+	return {
+		initForm : initForm,
+		setLocale : setLocale
+	}
+}();
+
+$(document).ready(function() {
+	requestSmokeAlarm.initForm();
+
+	var locale = /locale=([^;]+)/.exec(document.cookie);
+
+	$('.language-toggle').on('click', function() {
+		var lang = $(this).data('lang');
+		requestSmokeAlarm.setLocale(lang);
+	});
+})

--- a/views/index.jade
+++ b/views/index.jade
@@ -3,9 +3,9 @@ extends layout
 block content
   #container.container-fluid
     #language
-      a(onclick='setLocale("EN")') English
+      a.language-toggle(data-lang='en') English
       | &nbsp;|&nbsp;
-      a(onclick='setLocale("ES")') Español
+      a.language-toggle(data-lang='es') Español
     #top
       #logo.text-center
         img.logo(src='./smokeAlarmPortal_files/redcross-logo-white-letters.png', alt='American Red Cross')
@@ -133,18 +133,7 @@ block content
         |.
 
     script(type="text/javascript").
-      function setLocale(locale) { document.cookie= "locale=" + locale; location.reload(); }
-      var locale = /locale=([^;]+)/.exec(document.cookie);
-
-      if (locale && locale[1]) {
-        $("select#language-switcher").val(locale[1]);
-      }
-      $("select#state").addClass('state-not-yet-selected');
-      $("select#state").bind("focus", function () {
-        $(this).children('option[value="state-not-yet-selected"]').remove();
-        $(this).removeClass('state-not-yet-selected');
-      });
-      
+      // data for jquery error tootips, translated by i18n
       $(".form-horizontal").validationEngine({
         'scroll': false,
         'autoPositionUpdate': true,

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -36,7 +36,8 @@ html(lang='en')
     script(type='text/javascript', src='/third-party/jquery.validationEngine.js')
     link(rel='stylesheet', type='text/css', href='/third-party/validationEngine.jquery.css')
 
-    // Local stylesheets
+    // Local stylesheets and js
+    script(type='text/javascript', src='/js/main.js')
 
     // The DCSOps stylesheet messes up how bootstrap columns behave when collaped
     // link(rel='stylesheet', type='text/css', href='./smokeAlarmPortal_files/DCSOps.css')


### PR DESCRIPTION
This PR pulls the JS logic out of ```index.jade```.  The events for setting the language locale and the form initialization is now handled in ```main.js```. 

Note that the data that populates the validationEngine tooltips was left in the Jade template for now to ensure translation updates. Note also that I didn't have the mail functionality set up on my local, so that may be something to test before pulling this in. :)