### PR TITLE
Fix CSV exports when no region selected #160

### DIFF
--- a/views/admin/requests/index.js
+++ b/views/admin/requests/index.js
@@ -165,12 +165,6 @@ exports.find = function(req, res, next) {
                 // get no results.
                 filters.assigned_rc_region = entered_regions;
             }
-            // if they are allowed to see some regions and haven't
-            // filtered, show them all the results they're allowed to
-            // see
-            else if (allowed_regions.length > 0 && ! entered_regions) {
-                filters.assigned_rc_region = allowed_regions;
-            }
             else {
                 // TODO: then they don't have access to any regions and
                 // should not get any results.


### PR DESCRIPTION
Previously when no region was selected, the exported CSV file
contained all allowed data. Remove the codeblock that caused this, in
order to keep displayed exported data congruent with displayed data,
which is blank in this case. I don't understand exactly why this was
there originally, but @murraymel and I discussed it with @cecilia-donnelly 
and @kfogel we agreed that a blank CSV is expected.