### PR TITLE
#208 Change serial to public id for clarity

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,6 +132,7 @@ be edited here.
         # you're setting up an empty database) you can skip these migrations.
         smokealarm_development=# \i migrations/20151208-add-nonregion-code.sql
         smokealarm_development=# \i migrations/20151217-set-new-status.sql
+        smokealarm_development=# \i migrations/20160806-rename-serial-to-public-id.sql
 
         ### exit psql
         smokealarm_development=# \q        

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -13,7 +13,7 @@ A list of tests to be included in future unit tests:
   - nonexistent zip code gets "Sorry, we didn't recognize..."
   - existent zip without region gets "Sorry" with correct county
   - zip in inactive region gets "Sorry" with correct county
-  - zip in active region gets "Thank you" with ID (serial number)
+  - zip in active region gets "Thank you" with ID (public id)
 - "Thank you" or "Sorry" page shows up as expected
 - Email is sent to correct person/people
 
@@ -45,7 +45,7 @@ A list of tests to be included in future unit tests:
 - all SMS's send, in correct order, in any language
 - save the provided phone number or the "from" number, as directed
 - the correct information is saved in the database
-- requester receives correct final response (sorry, or thank you with serial)
+- requester receives correct final response (sorry, or thank you with public id)
 - suggested texts:
   - active region in english
   - active region in spanish
@@ -76,7 +76,7 @@ A list of tests to be included in future unit tests:
 - selected filters are maintained in exported file
 - all results are exported (not just the first page)
 - after export, new filters/sorting can be applied without error
-- CSV includes correct serial number and region
+- CSV includes correct ID number (public id) and region
 
 ## Kiosk
 

--- a/models/request.js
+++ b/models/request.js
@@ -30,7 +30,7 @@ module.exports = function(sequelize, DataTypes) {
         sms_raw_phone: DataTypes.TEXT,
 	email: DataTypes.TEXT,
         source: DataTypes.TEXT,
-        serial: { type: DataTypes.TEXT, unique: true },
+        public_id: { type: DataTypes.TEXT, unique: true },
         status: DataTypes.TEXT
     })
 }

--- a/routes.js
+++ b/routes.js
@@ -116,9 +116,9 @@ exports = module.exports = function(app, passport) {
 
   //admin > requests
   app.get('/admin/requests/', require('./views/admin/requests/index').find);
-  app.put('/admin/requests/:id/', require('./views/admin/requests/index').update);
-  app.get('/admin/requests/:id/', require('./views/admin/requests/index').read);
-  app.delete('/admin/requests/:id/', require('./views/admin/requests/index').delete);
+  app.put('/admin/requests/:publicId/', require('./views/admin/requests/index').update);
+  app.get('/admin/requests/:publicId/', require('./views/admin/requests/index').read);
+  app.delete('/admin/requests/:publicId/', require('./views/admin/requests/index').delete);
 
 
   //admin > users

--- a/views/admin/requests/index.jade
+++ b/views/admin/requests/index.jade
@@ -123,7 +123,7 @@ block body
                option(value='inprogress') in-progress
                option(value='installed') installed
                option(value='canceled') canceled
-    td <%- serial %>
+    td <%- public_id %>
     td <%- name %>
     td <%- address %>
     td <%- city %>

--- a/views/admin/requests/index.js
+++ b/views/admin/requests/index.js
@@ -240,7 +240,7 @@ var getResults = function(callback) {
 
     var createCSV = function() {
         var requestFieldNames = ['id','name','address','city','state','zip','phone','email','date created','region'];
-        var requestFields = ['serial','name','address','city','state','zip','phone','email','createdAt','assigned_rc_region'];
+        var requestFields = ['public_id','name','address','city','state','zip','phone','email','createdAt','assigned_rc_region'];
         json2csv({ data: outcome.results, fields: requestFields, fieldNames: requestFieldNames }, function(err, csv) {
             if (err) console.log("ERROR: error converting to CSV" + err);
             res.setHeader('Content-Type','application/csv');

--- a/views/index.js
+++ b/views/index.js
@@ -31,7 +31,7 @@ exports.saveRequest = function(req, res) {
         return utils.countRequestsPerRegion(region_code);
     }).then( function(numRequests) {
         requestData = utils.getRequestData(req, numRequests, region_code);
-        requestData = utils.createSerial(numRequests, requestData, region_code);
+        requestData = utils.createPublicId(numRequests, requestData, region_code);
         requestData.is_sms = 'web';
         return utils.saveRequestData(requestData);
     }).then(function(request) {
@@ -40,7 +40,7 @@ exports.saveRequest = function(req, res) {
     }).then( function(activeRegion){
         if (activeRegion) {
             utils.sendEmail(savedRequest, activeRegion);
-            res.render('thankyou.jade', {region: activeRegion.region_name, id: savedRequest.serial, origin: req.url});
+            res.render('thankyou.jade', {region: activeRegion.region_name, id: savedRequest.public_id, origin: req.url});
         }
         else{
             res.render('sorry.jade', {county: requestData.countyFromZip, state: requestData.stateFromZip, zip: requestData.zip_for_lookup, origin: req.url});

--- a/views/sms/index.js
+++ b/views/sms/index.js
@@ -151,11 +151,11 @@ exports.respond = function(req, res) {
      * Takes: the "outcome" (a boolean that is true iff the entered zip code
      * is valid and in an active region),
      * If the outcome was successful:
-     * serial: the serial number assigned to the request
+     * public_id: the unique ID number assigned to the request
      * county: the county found based on the entered zipcode
      * contact: the phone number for this RC region
      *
-     * Returns: a message with "thank you," the serial number, and a contact
+     * Returns: a message with "thank you," the ID number (public id), and a contact
      * phone for successful outcomes and a "sorry" message with a generic RC
      * phone number for out-of-area zip codes (just like the website).
      */
@@ -163,7 +163,7 @@ exports.respond = function(req, res) {
         var twiml = new twilio.TwimlResponse();
         if (outcome) {
             msg = __("Thank you for your smoke alarm request! Your request number is %s.");
-            msg = msg.replace('%s', request.serial);
+            msg = msg.replace('%s', request.public_id);
             msg += __(" To contact your local Red Cross about this request, call 1-800-RED-CROSS (1-800-733-2767). We will be in touch with you to schedule an installation.");
         }
         else {
@@ -240,7 +240,7 @@ exports.respond = function(req, res) {
             req.cookies.request_object.assigned_rc_region = region_code;
             return save_utils.countRequestsPerRegion(region_code);
         }).then( function(numRequests) {
-            requestData = save_utils.createSerial(numRequests, req.cookies.request_object, region_code);
+            requestData = save_utils.createPublicId(numRequests, req.cookies.request_object, region_code);
             requestData.is_sms = 'sms';
             requestData.name = req.cookies.priorities.name.value;
             requestData.phone = req.cookies.priorities.phone.value;

--- a/views/utilities.js
+++ b/views/utilities.js
@@ -191,12 +191,11 @@ module.exports  = {
         return requestData;
     },
 
-    createSerial: function (numberOfRequests, requestData, region) {
+    createPublicId: function (numberOfRequests, requestData, region) {
         // construct today date object
         var today = new Date();
-        // avoid the first request having a serial number of
-        // "region-date-00000."  I think that would be confusing for users.
-        // We might as well start with 1.
+        // avoid the first request having a public_id of "region-date-00000."
+        // I think that would be confusing for users; we might as well start with 1.
         numberOfRequests = numberOfRequests + 1;
         var sequenceNumber = module.exports.padWithZeroes(numberOfRequests.toString(), 5);
          // find fiscal year
@@ -208,7 +207,7 @@ module.exports  = {
         }
         var displayedYear = fiscalYear - 2000;
         if (region) {
-            var serial = region + "-" + displayedYear + "-" + sequenceNumber;
+            var public_id = region + "-" + displayedYear + "-" + sequenceNumber;
         }
         else {
             // construct code from state
@@ -220,10 +219,10 @@ module.exports  = {
             else {
                 state_code = "XXXX";
             }
-            var serial = state_code + "-" + displayedYear + "-" + sequenceNumber;
+            var public_id = state_code + "-" + displayedYear + "-" + sequenceNumber;
         }
 
-        requestData.serial = serial;
+        requestData.public_id = public_id;
         return requestData;
     },
 
@@ -255,14 +254,14 @@ module.exports  = {
             phone: requestData.phone,
             sms_raw_phone: requestData.raw_phone,
             email: requestData.email,
-            serial: requestData.serial,
+            public_id: requestData.public_id,
             assigned_rc_region: requestData.assigned_rc_region,
             status: 'new'
         }).catch( function () {
-            // uniqueness failed; increment serial
-            var serial_array = requestData.serial.split("-");
-            var new_serial = module.exports.padWithZeroes((parseInt(serial_array[2]) + 1).toString(), 5);
-            requestData.serial = serial_array[0] + "-" + serial_array[1] + "-" + new_serial;
+            // uniqueness failed; increment public_id
+            var public_id_array = requestData.public_id.split("-");
+            var new_public_id = module.exports.padWithZeroes((parseInt(public_id_array[2]) + 1).toString(), 5);
+            requestData.public_id = public_id_array[0] + "-" + public_id_array[1] + "-" + new_public_id;
             return saveRequestData(requestData); //loop until save works
         });
     },
@@ -329,7 +328,7 @@ module.exports  = {
         var regionPresentableName = selectedRegion.region_name;
         var regionRecipientName   = selectedRegion.contact_name;
         var regionRecipientEmail  = selectedRegion.contact_email;
-        var thisRequestID = request.serial;
+        var thisRequestID = request.public_id;
 
         var email_text = "We have received a smoke alarm installation request from:\n"
             + "\n"


### PR DESCRIPTION
Change `serial` to `public_id`. 
## Issue #208

`serial` is a non-intuitive internal representation of the `id` we commonly expose to users of the system. When trying to map the `id` from CSV exports, searches, emails and SMS back to internal code this is confusing. 
## Solution

Switch the model to rename `serial` to `public_id`. The `public_id` is the id exposed to users as `id` where the internal database `id` will be something altogether different. The domain language would be something like:

`When talking about id, it's almost always what is exposed to users: the public id. Only postgres cares about a different id.`
