### PR TITLE
Add model and handler for duplicates, update admin export

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -142,6 +142,9 @@ be edited here.
         ### exit psql
         smokealarm_development=# \q        
 
+        ### Run sequelize migrations
+        sequelize db:migrate
+
         ### FOR DEVELOPMENT, load sample requests:
         $ node data/fake_request_data.js 
 

--- a/migrations/20170901190048-create-request-duplicate.js
+++ b/migrations/20170901190048-create-request-duplicate.js
@@ -1,6 +1,6 @@
 /* Smoke Alarm Installation Request Portal (getasmokealarm.org)
  * 
- * Copyright (C) 2015  American Red Cross
+ * Copyright (C) 2017  American Red Cross
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/migrations/20170901190048-create-request-duplicate.js
+++ b/migrations/20170901190048-create-request-duplicate.js
@@ -16,28 +16,33 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-module.exports = function(sequelize, DataTypes) {
-  var Request = sequelize.define('Request', {
-    name: DataTypes.TEXT,
-    address: DataTypes.TEXT,
-          sms_raw_address: DataTypes.TEXT,
-    assigned_rc_region: DataTypes.TEXT,
-    city: DataTypes.TEXT,
-    state: DataTypes.TEXT,
-    zip: DataTypes.TEXT,
-          sms_raw_zip: DataTypes.TEXT,
-    phone: DataTypes.TEXT,
-          sms_raw_phone: DataTypes.TEXT,
-    email: DataTypes.TEXT,
-          source: DataTypes.TEXT,
-          serial: { type: DataTypes.TEXT, unique: true },
-          status: DataTypes.TEXT
-  }, {
-    classMethods: {
-      associate: function(models) {
-        Request.hasMany(models.RequestDuplicate, { name: "requestId" });
+'use strict';
+
+module.exports = {
+  up: function(queryInterface, Sequelize) {
+    return queryInterface.createTable('RequestDuplicates', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      requestId: {
+        type: Sequelize.INTEGER,
+        onDelete: 'CASCADE',
+        references: { model: 'Requests', key: 'id' }
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
       }
-    }
-  });
-  return Request;
-}
+    });
+  },
+  down: function(queryInterface, Sequelize) {
+    return queryInterface.dropTable('RequestDuplicates');
+  }
+};

--- a/models/request.js
+++ b/models/request.js
@@ -35,7 +35,7 @@ module.exports = function(sequelize, DataTypes) {
   }, {
     classMethods: {
       associate: function(models) {
-        Request.hasMany(models.RequestDuplicate, { name: "requestId" });
+        Request.hasMany(models.RequestDuplicate, { foreignKey: "requestId" });
       }
     }
   });

--- a/models/request.js
+++ b/models/request.js
@@ -20,18 +20,18 @@ module.exports = function(sequelize, DataTypes) {
   var Request = sequelize.define('Request', {
     name: DataTypes.TEXT,
     address: DataTypes.TEXT,
-          sms_raw_address: DataTypes.TEXT,
+    sms_raw_address: DataTypes.TEXT,
     assigned_rc_region: DataTypes.TEXT,
     city: DataTypes.TEXT,
     state: DataTypes.TEXT,
     zip: DataTypes.TEXT,
-          sms_raw_zip: DataTypes.TEXT,
+    sms_raw_zip: DataTypes.TEXT,
     phone: DataTypes.TEXT,
-          sms_raw_phone: DataTypes.TEXT,
+    sms_raw_phone: DataTypes.TEXT,
     email: DataTypes.TEXT,
-          source: DataTypes.TEXT,
-          serial: { type: DataTypes.TEXT, unique: true },
-          status: DataTypes.TEXT
+    source: DataTypes.TEXT,
+    serial: { type: DataTypes.TEXT, unique: true },
+    status: DataTypes.TEXT
   }, {
     classMethods: {
       associate: function(models) {

--- a/models/requestduplicate.js
+++ b/models/requestduplicate.js
@@ -16,28 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+'use strict';
+
 module.exports = function(sequelize, DataTypes) {
-  var Request = sequelize.define('Request', {
-    name: DataTypes.TEXT,
-    address: DataTypes.TEXT,
-          sms_raw_address: DataTypes.TEXT,
-    assigned_rc_region: DataTypes.TEXT,
-    city: DataTypes.TEXT,
-    state: DataTypes.TEXT,
-    zip: DataTypes.TEXT,
-          sms_raw_zip: DataTypes.TEXT,
-    phone: DataTypes.TEXT,
-          sms_raw_phone: DataTypes.TEXT,
-    email: DataTypes.TEXT,
-          source: DataTypes.TEXT,
-          serial: { type: DataTypes.TEXT, unique: true },
-          status: DataTypes.TEXT
-  }, {
+  var RequestDuplicate = sequelize.define('RequestDuplicate', {}, {
     classMethods: {
       associate: function(models) {
-        Request.hasMany(models.RequestDuplicate, { name: "requestId" });
+        RequestDuplicate.belongsTo(models.Request, { onDelete: "CASCADE", foreignKey: "requestId" });
       }
     }
   });
-  return Request;
-}
+  return RequestDuplicate;
+};

--- a/models/requestduplicate.js
+++ b/models/requestduplicate.js
@@ -1,6 +1,6 @@
 /* Smoke Alarm Installation Request Portal (getasmokealarm.org)
  * 
- * Copyright (C) 2015  American Red Cross
+ * Copyright (C) 2017  American Red Cross
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/views/admin/requests/index.js
+++ b/views/admin/requests/index.js
@@ -231,11 +231,11 @@ var getResults = function(callback) {
                     outcome.items.end = outcome.items.total;
                 }
 
-                outcome.results = results_array.map(function(r) {
-                  var duplicateCount = r.RequestDuplicates.length;
-                  r = r.toJSON();
-                  r.duplicate_count = duplicateCount;
-                  return r;
+                outcome.results = results_array.map(function(result) {
+                  var duplicateCount = result.RequestDuplicates.length;
+                  result = result.toJSON();
+                  result.duplicate_count = duplicateCount;
+                  return result;
                 });
                 return callback(null, 'done');
             })

--- a/views/admin/requests/index.js
+++ b/views/admin/requests/index.js
@@ -2,6 +2,8 @@
 var _ = require('underscore');
 var json2csv = require('json2csv');
 var moment = require('moment');
+var sequelize = require('sequelize');
+
 exports.find = function(req, res, next) {
     if (_.isUndefined(req.query.page)) {
         req.query.page = 1;
@@ -200,7 +202,8 @@ var getResults = function(callback) {
             limit: limit,
             offset: offset,
             where: filters,
-            order: [[req.query.sort.replace('-',''), sortOrder ]]
+            order: [[req.query.sort.replace('-',''), sortOrder ]],
+            include: [req.app.db.RequestDuplicate]
         }).reduce( function(previousValue, request, index, results) {
             return queryRegionPresentableName(request).then(
                 function (displayName) {
@@ -228,7 +231,12 @@ var getResults = function(callback) {
                     outcome.items.end = outcome.items.total;
                 }
 
-                outcome.results = results_array;
+                outcome.results = results_array.map(function(r) {
+                  var duplicateCount = r.RequestDuplicates.length;
+                  r = r.toJSON();
+                  r.duplicate_count = duplicateCount;
+                  return r;
+                });
                 return callback(null, 'done');
             })
             .catch(function(err) {
@@ -239,8 +247,8 @@ var getResults = function(callback) {
     };
 
     var createCSV = function() {
-        var requestFieldNames = ['id','name','address','city','state','zip','phone','email','date created','region', 'source'];
-        var requestFields = ['serial','name','address','city','state','zip','phone','email','createdAt','assigned_rc_region', 'source'];
+        var requestFieldNames = ['id','name','address','city','state','zip','phone','email','date created', 'date updated', 'region', 'source', 'count duplicates'];
+        var requestFields = ['serial','name','address','city','state','zip','phone','email','createdAt', 'updatedAt', 'assigned_rc_region', 'source', 'duplicate_count'];
         json2csv({ data: outcome.results, fields: requestFields, fieldNames: requestFieldNames }, function(err, csv) {
             if (err) console.log("ERROR: error converting to CSV" + err);
             res.setHeader('Content-Type','application/csv');

--- a/views/index.js
+++ b/views/index.js
@@ -40,7 +40,7 @@ exports.saveRequest = function(req, res) {
         else {
             requestData.source = 'web-home';
         }
-        return utils.saveRequestData(requestData);
+        return utils.saveOrDuplicateRequest(requestData);
     }).then(function(request) {
         savedRequest = request;
         return utils.isActiveRegion(savedRequest);

--- a/views/utilities.js
+++ b/views/utilities.js
@@ -244,7 +244,8 @@ module.exports  = {
             zip: requestData.zip_final,
             email: { $ilike: requestData.email },
             phone: { $like: phoneQuery },
-          }
+          },
+          order: '"createdAt" DESC'
       });
     },
 

--- a/views/utilities.js
+++ b/views/utilities.js
@@ -237,7 +237,6 @@ module.exports  = {
       return db.Request.findOne({
           where: {
             name: { $ilike: requestData.name },
-            source: requestData.source,
             address: { $ilike: requestData.street_address },
             city: { $ilike: requestData.city },
             state: { $ilike: requestData.state },


### PR DESCRIPTION
Should implement most of what's mentioned in #236, other than the admin interface. I created a `RequestDuplicate` model that just has the default fields and `requestId` as an association with the `Requests` table. Wanted to get some feedback before moving to the admin side of things though.

I tried to handle the promises as cleanly as possible in the `saveOrDuplicateRequest` function, but I'm not sure if there was a way of avoiding the nested promises there altogether. The `RequestDuplicate` model file was created from `sequelize-cli`, so to manage the association on the `Request` side of things I updated the request model file with the same general structure.