### PR TITLE
Modify validation rules for 311 page

### DIFF
--- a/locales/en.js
+++ b/locales/en.js
@@ -29,6 +29,7 @@
 	" at GitHub": " at GitHub",
 	"This field is required": "This field is required",
 	"Please provide either a 10-digit phone number or an email address": "Please provide either a 10-digit phone number or an email address",
+	"A 10-digit phone number is required": "A 10-digit phone number is required",
 	"The phone number is invalid": "The phone number is invalid",
 	"A valid US zip code is required": "A valid US zip code is required",
 	"Please provide either a phone number or an email address": "Please provide either a phone number or an email address",

--- a/locales/es.js
+++ b/locales/es.js
@@ -24,6 +24,7 @@
 	"Email": "Dirección de Correo Electrónico",
 	"This field is required": "Este campo es obligatorio",
 	"Please provide either a 10-digit phone number or an email address": "Por favor proporcione o bien un número de teléfono de 10 dígitos o una dirección de correo electrónico",
+	"A 10-digit phone number is required": "Un número de teléfono de 10 dígitos es obligatorio",
 	"The phone number is invalid": "El número de teléfono no es válido.",
 	"A valid US zip code is required": "Un código postal válido de EE.UU. es obligatorio",
 	"Please provide either a phone number or an email address": "Por favor proporcione o bien un número de teléfono o una dirección de correo electrónico",

--- a/views/index.jade
+++ b/views/index.jade
@@ -142,16 +142,7 @@ block content
 
     script(type="text/javascript").
       // data for jquery error tootips, translated by i18n
-      $(".form-horizontal").validationEngine({
-        'scroll': false,
-        'autoPositionUpdate': true,
-        'maxErrorsPerField': 1,
-        'onValidationComplete': function() {
-          $("#singlebutton").prop("disabled", true);
-          $("img.loader").show();
-          return true;
-        },
-        'custom_error_messages': {
+      var validationRules = {
           '#name': {
             'required': {
               'message': "* " + "#{__('This field is required')}"
@@ -196,7 +187,30 @@ block content
               'message': "* " + "#{__('The email address is invalid')}"
             }
           }
-        }
+      };
+      // Change validation rules for contact info on 311
+      if (window.location.pathname.substr(0, 4) === '/311') {
+        // Delete contact rules from object, change custom validation classes
+        delete validationRules['#email']['custom[email'];
+        delete validationRules['#phone']['groupRequired'];
+        $('#phone, #email').attr('class', 'form-control input-md');
+        $('#email').addClass('validate[custom[email]]');
+        $('#phone').addClass('validate[required, custom[phone-10-digit-US]]');
+
+        validationRules['#phone']['required'] = {
+          'message': '* ' + "#{__('A 10-digit phone number is required')}"
+        };
+      }
+      $(".form-horizontal").validationEngine({
+        'scroll': false,
+        'autoPositionUpdate': true,
+        'maxErrorsPerField': 1,
+        'onValidationComplete': function() {
+          $("#singlebutton").prop("disabled", true);
+          $("img.loader").show();
+          return true;
+        },
+        'custom_error_messages': validationRules
       });
       // Fix Safari font-weight. The bizzare if-clause is feature-detection for Safari.
       if (Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0) { $("body").css("font-weight", "400"); }

--- a/views/index.jade
+++ b/views/index.jade
@@ -196,6 +196,7 @@ block content
         $('#phone, #email').attr('class', 'form-control input-md');
         $('#email').addClass('validate[custom[email]]');
         $('#phone').addClass('validate[required, custom[phone-10-digit-US]]');
+        $('#phone').attr('required', true);
 
         validationRules['#phone']['required'] = {
           'message': '* ' + "#{__('A 10-digit phone number is required')}"


### PR DESCRIPTION
Fixes #234. If the pathname starts with "/311", phone is required for contact information rather than phone or email. Removes the custom validation rules classes on elements, and replaces them with the updated rules. Also adds internationalization for the validation message. I modified the Spanish translation from similar messages, and I have a little bit of Spanish knowledge, but if that needs fixing I can change that.

One other thing I wanted to call out is whenever I run `npm start` it updates the `locales/en.js` file. I removed those changes from the commit to keep it clean, but if I set something up in a way that's causing that let me know!