### PR TITLE
Change text on login screen to fix #246

### DIFF
--- a/views/login/index.jade
+++ b/views/login/index.jade
@@ -54,7 +54,7 @@ block body
           |<%- err %>
         |<% }); %>
       div.form-group(class!='<%- errfor.username ? "has-error" : "" %>')
-        label Username or Email:
+        label Username:
         input.form-control(type='text', name='username', value!='<%= username %>')
         span.help-block <%- errfor.username %>
       div.form-group(class!='<%- errfor.password ? "has-error" : "" %>')


### PR DESCRIPTION
Accurately state that users must use their username, not email address,
to log in.

Quick fix for a bug that's causing users to have trouble logging in.