### PR TITLE
Increase body font weight

### DIFF
--- a/public/smokeAlarmPortal_files/base.css
+++ b/public/smokeAlarmPortal_files/base.css
@@ -50,7 +50,7 @@ body {
     /* background: url("../images/install_combined.jpg"); */
     color: #EEE;
     font-family: "Helvetica Neue", smokeAlarmDefault, Helvetica, Arial, sans-serif;
-    font-weight: 100;
+    font-weight: normal;
     font-size: 1.6em;
 }
 


### PR DESCRIPTION
Closes #260. Increases the default font weight from 100 to `normal` so that it's more legible. This is currently live at https://demo.getasmokealarm.org/ if anyone wants to take a look, @OhMcGoo 

Here's a screenshot on Safari:
<img width="1161" alt="screen shot 2018-05-17 at 3 14 07 pm" src="https://user-images.githubusercontent.com/8291663/40201548-fb64e2ee-59e4-11e8-8128-7b9d35ea6ad6.png">
