### PR TITLE
Add sudo option for running `psql` to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,6 +96,8 @@ be edited here.
         $ psql
         ### Approach 2: use your user if you have access
         $ psql postgres
+        ### Approach 3: use `sudo` to execute `psql` as the `postgres` user
+        $ sudo -u postgres psql
 
 
         ### Now you can setup the database/user/rights


### PR DESCRIPTION
I had to figure out this option when installing because I didn't have the password for the postgres user (option 1) and my user didn't have access (option 2).  So I thought it was worth adding to the INSTALL.md doc.