### PR TITLE
Add admin interface

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,6 +103,7 @@ app.use(function(req, res, next) {
     res.locals.user = {};
     res.locals.user.defaultReturnUrl = req.user && req.user.defaultReturnUrl();
     res.locals.user.username = req.user && req.user.username;
+    res.locals.user.siteAdmin = req.user && req.user.siteAdmin;
     next();
 });
 

--- a/migrations/20181002112711-add-site-admin-flag.js
+++ b/migrations/20181002112711-add-site-admin-flag.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('User', 'siteAdmin', Sequelize.BOOLEAN);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('User', 'siteAdmin');
+  }
+};

--- a/models/User.js
+++ b/models/User.js
@@ -29,6 +29,7 @@ module.exports = function(sequelize, DataTypes) {
             unique: true
         },
         isActive: DataTypes.TEXT,
+        siteAdmin: DataTypes.BOOLEAN,
         resetPasswordToken: DataTypes.TEXT,
         resetPasswordExpires: DataTypes.DATE,
         twitter: DataTypes.JSON,

--- a/models/index.js
+++ b/models/index.js
@@ -67,6 +67,21 @@ db.regionPermission.belongsTo(db.User, {foreignKey:'user_id'});
 db.activeRegion.hasMany(db.regionPermission, {foreignKey:'rc_region'});
 db.SelectedCounties.hasMany(db.Request, {foreignKey:'selected_county'});
 
+db.User.belongsToMany(
+    db.activeRegion,
+    {
+        through: { model: db.regionPermission, unique: false },
+        foreignKey: 'user_id'
+    }
+);
+db.activeRegion.belongsToMany(
+    db.User,
+    {
+        through: { model: db.regionPermission, unique: false },
+        foreignKey: 'rc_region'
+    }
+);
+
 db.sequelize.sync(options);
 
 // TODO: This is a temporary kludge.  These shouldn't really be part

--- a/public/views/admin/users/details.js
+++ b/public/views/admin/users/details.js
@@ -31,6 +31,7 @@
       errors: [],
       errfor: {},
       siteAdmin: false,
+      isActive: false,
       username: '',
       email: ''
     },
@@ -133,6 +134,7 @@
       this.model.set({
         _id: app.mainView.model.id,
         siteAdmin: app.mainView.model.get('siteAdmin'),
+        isActive: app.mainView.model.get('isActive') == 'yes',
         username: app.mainView.model.get('username'),
         email: app.mainView.model.get('email')
       });
@@ -141,12 +143,14 @@
       this.$el.html(this.template( this.model.attributes ));
 
       this.$el.find('[name="siteAdmin"]').prop('checked', this.model.attributes['siteAdmin']);
+      this.$el.find('[name="isActive"]').prop('checked', this.model.attributes['isActive']);
       this.$el.find('[name="username"]').val(this.model.attributes['username']);
       this.$el.find('[name="email"]').val(this.model.attributes['email']);
     },
     update: function() {
       this.model.save({
         siteAdmin: this.$el.find('[name="siteAdmin"]').prop("checked"),
+        isActive: this.$el.find('[name="isActive"]').prop("checked"),
         username: this.$el.find('[name="username"]').val(),
         email: this.$el.find('[name="email"]').val()
       });

--- a/public/views/admin/users/details.js
+++ b/public/views/admin/users/details.js
@@ -6,7 +6,7 @@
   app = app || {};
 
   app.User = Backbone.Model.extend({
-    idAttribute: '_id',
+    idAttribute: 'id',
     url: function() {
       return '/admin/users/'+ this.id +'/';
     }
@@ -53,7 +53,6 @@
       success: false,
       errors: [],
       errfor: {},
-      roles: {},
       newAccountId: '',
       newAdminId: ''
     },
@@ -144,91 +143,6 @@
     }
   });
 
-  app.RolesView = Backbone.View.extend({
-    el: '#roles',
-    template: _.template( $('#tmpl-roles').html() ),
-    events: {
-      'click .btn-admin-open': 'adminOpen',
-      'click .btn-admin-link': 'adminLink',
-      'click .btn-admin-unlink': 'adminUnlink',
-      'click .btn-account-open': 'accountOpen',
-      'click .btn-account-link': 'accountLink',
-      'click .btn-account-unlink': 'accountUnlink'
-    },
-    initialize: function() {
-      this.model = new app.Roles();
-      this.syncUp();
-      this.listenTo(app.mainView.model, 'change', this.syncUp);
-      this.listenTo(this.model, 'sync', this.render);
-      this.render();
-    },
-    syncUp: function() {
-      this.model.set({
-        _id: app.mainView.model.id,
-        roles: app.mainView.model.get('roles')
-      });
-    },
-    render: function() {
-      this.$el.html(this.template( this.model.attributes ));
-
-      for (var key in this.model.attributes) {
-        if (this.model.attributes.hasOwnProperty(key)) {
-          this.$el.find('[name="'+ key +'"]').val(this.model.attributes[key]);
-        }
-      }
-    },
-    adminOpen: function() {
-      location.href = '/admin/administrators/'+ this.model.get('roles').admin._id +'/';
-    },
-    adminLink: function() {
-      this.model.save({
-        newAdminId: $('[name="newAdminId"]').val()
-      },{
-        url: this.model.url() +'role-admin/'
-      });
-    },
-    adminUnlink: function() {
-      if (confirm('Are you sure?')) {
-        this.model.destroy({
-          url: this.model.url() +'role-admin/',
-          success: function(model, response) {
-            if (response.user) {
-              app.mainView.model.set(response.user);
-              delete response.user;
-            }
-
-            app.rolesView.model.set(response);
-          }
-        });
-      }
-    },
-    accountOpen: function() {
-      location.href = '/admin/accounts/'+ this.model.get('roles').account._id +'/';
-    },
-    accountLink: function() {
-      this.model.save({
-        newAccountId: $('[name="newAccountId"]').val()
-      },{
-        url: this.model.url() +'role-account/'
-      });
-    },
-    accountUnlink: function() {
-      if (confirm('Are you sure?')) {
-        this.model.destroy({
-          url: this.model.url() +'role-account/',
-          success: function(model, response) {
-            if (response.user) {
-              app.mainView.model.set(response.user);
-              delete response.user;
-            }
-
-            app.rolesView.model.set(response);
-          }
-        });
-      }
-    }
-  });
-
   app.PasswordView = Backbone.View.extend({
     el: '#password',
     template: _.template( $('#tmpl-password').html() ),
@@ -296,7 +210,6 @@
       app.headerView = new app.HeaderView();
       app.identityView = new app.IdentityView();
       app.passwordView = new app.PasswordView();
-      app.rolesView = new app.RolesView();
       app.deleteView = new app.DeleteView();
     }
   });

--- a/public/views/admin/users/details.js
+++ b/public/views/admin/users/details.js
@@ -30,7 +30,7 @@
       success: false,
       errors: [],
       errfor: {},
-      isActive: '',
+      siteAdmin: false,
       username: '',
       email: ''
     },
@@ -120,7 +120,7 @@
     syncUp: function() {
       this.model.set({
         _id: app.mainView.model.id,
-        isActive: app.mainView.model.get('isActive'),
+        siteAdmin: app.mainView.model.get('siteAdmin'),
         username: app.mainView.model.get('username'),
         email: app.mainView.model.get('email')
       });
@@ -128,15 +128,13 @@
     render: function() {
       this.$el.html(this.template( this.model.attributes ));
 
-      for (var key in this.model.attributes) {
-        if (this.model.attributes.hasOwnProperty(key)) {
-          this.$el.find('[name="'+ key +'"]').val(this.model.attributes[key]);
-        }
-      }
+      this.$el.find('[name="siteAdmin"]').prop('checked', this.model.attributes['siteAdmin']);
+      this.$el.find('[name="username"]').val(this.model.attributes['username']);
+      this.$el.find('[name="email"]').val(this.model.attributes['email']);
     },
     update: function() {
       this.model.save({
-        isActive: this.$el.find('[name="isActive"]').val(),
+        siteAdmin: this.$el.find('[name="siteAdmin"]').prop("checked"),
         username: this.$el.find('[name="username"]').val(),
         email: this.$el.find('[name="email"]').val()
       });

--- a/public/views/admin/users/index.js
+++ b/public/views/admin/users/index.js
@@ -77,7 +77,7 @@
           success: function(model, response) {
             if (response.success) {
               model.id = response.record._id;
-              location.href = model.url();
+              location.href = model.url() + response.record.id + "/";
             }
             else {
               alert(response.errors.join('\n'));

--- a/public/views/admin/users/index.js
+++ b/public/views/admin/users/index.js
@@ -34,7 +34,6 @@
   app.Filter = Backbone.Model.extend({
     defaults: {
       username: '',
-      roles: '',
       isActive: '',
       sort: '',
       limit: ''
@@ -98,7 +97,7 @@
     el: '#results-table',
     template: _.template( $('#tmpl-results-table').html() ),
     initialize: function() {
-      this.collection = new app.RecordCollection( app.mainView.results.data );
+      this.collection = new app.RecordCollection( app.mainView.results );
       this.listenTo(this.collection, 'reset', this.render);
       this.render();
     },
@@ -125,7 +124,7 @@
       'click .btn-details': 'viewDetails'
     },
     viewDetails: function() {
-      location.href = this.model.url();
+      location.href = this.model.url() + this.model.attributes.id + "/";
     },
     render: function() {
       this.$el.html(this.template( this.model.attributes ));

--- a/public/views/admin/users/index.js
+++ b/public/views/admin/users/index.js
@@ -11,7 +11,7 @@
       _id: undefined,
       username: '',
       email: '',
-      isActive: ''
+      siteAdmin: ''
     },
     url: function() {
       return '/admin/users/'+ (this.isNew() ? '' : this.id +'/');
@@ -34,7 +34,7 @@
   app.Filter = Backbone.Model.extend({
     defaults: {
       username: '',
-      isActive: '',
+      siteAdmin: '',
       sort: '',
       limit: ''
     }

--- a/public/views/admin/users/index.js
+++ b/public/views/admin/users/index.js
@@ -22,12 +22,7 @@
     model: app.Record,
     url: '/admin/users/',
     parse: function(results) {
-      app.pagingView.model.set({
-        pages: results.pages,
-        items: results.items
-      });
-      app.filterView.model.set(results.filters);
-      return results.data;
+      return results;
     }
   });
 

--- a/routes.js
+++ b/routes.js
@@ -130,6 +130,7 @@ exports = module.exports = function(app, passport) {
   app.post('/admin/users/', require('./views/admin/users/index').create);
   app.get('/admin/users/:id/', require('./views/admin/users/index').read);
   app.put('/admin/users/:id/', require('./views/admin/users/index').update);
+  app.put('/admin/users/:id/regions/', require('./views/admin/users/index').regions);
   app.put('/admin/users/:id/password/', require('./views/admin/users/index').password);
   app.put('/admin/users/:id/role-admin/', require('./views/admin/users/index').linkAdmin);
   app.delete('/admin/users/:id/role-admin/', require('./views/admin/users/index').unlinkAdmin);

--- a/routes.js
+++ b/routes.js
@@ -27,8 +27,8 @@ function ensureAuthenticated(req, res, next) {
   res.redirect('/login/');
 }
 
-function ensureAdmin(req, res, next) {
-  if (req.user.canPlayRoleOf('admin')) {
+function ensureSiteAdmin(req, res, next) {
+  if (req.user.siteAdmin) {
     return next();
   }
   res.redirect('/');
@@ -114,7 +114,6 @@ exports = module.exports = function(app, passport) {
 
   //admin
   app.all('/admin*', ensureAuthenticated);
-  app.all('/admin*', ensureAdmin);
   app.get('/admin/', require('./views/admin/index').init);
 
   //admin > requests
@@ -125,6 +124,7 @@ exports = module.exports = function(app, passport) {
 
 
   //admin > users
+  app.all('/admin/users*', ensureSiteAdmin);
   app.get('/admin/users/', require('./views/admin/users/index').find);
   app.post('/admin/users/', require('./views/admin/users/index').create);
   app.get('/admin/users/:id/', require('./views/admin/users/index').read);

--- a/routes.js
+++ b/routes.js
@@ -54,6 +54,7 @@ function ensureSignupEnabled(req, res, next) {
   }
 }
 exports = module.exports = function(app, passport) {
+  app.locals.pretty = true;
   //front end
   app.get('/', require('./views/index').init);
   app.post('/', require('./views/index').saveRequest);

--- a/routes.js
+++ b/routes.js
@@ -19,7 +19,7 @@
 'use strict';
 
 function ensureAuthenticated(req, res, next) {
-  if (req.isAuthenticated()) {
+  if (req.isAuthenticated() && req.user.isActive == 'yes') {
     return next();
   }
   res.set('X-Auth-Required', 'true');

--- a/views/admin/index.jade
+++ b/views/admin/index.jade
@@ -10,5 +10,10 @@ block body
   div.row
     div.col-sm-3
       div.page-header
-        p Reports:
-        a(href='/admin/requests/') Smoke Alarm Installation Requests
+        h2 Reports:
+        p
+          a(href='/admin/requests/') Smoke Alarm Installation Requests
+        if user.siteAdmin
+          h2 Administration:
+          p
+            a(href='/admin/users/') Users

--- a/views/admin/users/details.jade
+++ b/views/admin/users/details.jade
@@ -4,14 +4,13 @@ block head
   title Users / Details
 
 block feet
-  script(src='/views/admin/users/details.min.js?#{cacheBreaker}')
+  script(src='/views/admin/users/details.js')
 
 block body
   div.row
     div.col-xs-12
       div#header
       div#identity
-      div#roles
       div#password
       div#delete
 
@@ -51,45 +50,6 @@ block body
         span.help-block <%- errfor.email %>
       div.form-group
         button.btn.btn-primary.btn-update(type='button') Update
-
-  script(type='text/template', id='tmpl-roles')
-    fieldset
-      legend Roles
-      div.alerts
-        |<% _.each(errors, function(err) { %>
-        div.alert.alert-danger.alert-dismissable
-          button.close(type='button', data-dismiss='alert') &times;
-          |<%- err %>
-        |<% }); %>
-      div.form-group(class!='<%- errfor.newAdminId ? "has-error" : "" %>')
-        label Admin:
-        div.controls
-          div.input-group
-            |<% if (roles && roles.admin) { %>
-            input.form-control(disabled=true, value!='<%= roles.admin.name.full %>')
-            div.input-group-btn
-              button.btn.btn-warning.btn-admin-unlink(type='button') Unlink
-              button.btn.btn-default.btn-admin-open(type='button') Open
-            |<% } else { %>
-            input.form-control(name='newAdminId', type='text', placeholder='enter admin id')
-            div.input-group-btn
-              button.btn.btn-success.btn-admin-link(type='button') Link
-            |<% } %>
-          span.help-block <%- errfor.newAdminId %>
-      div.form-group(class!='<%- errfor.newAccountId ? "has-error" : "" %>')
-        label Account:
-        div.input-group
-          |<% if (roles && roles.account) { %>
-          input.form-control(disabled=true, value!='<%= roles.account.name.full %>')
-          div.input-group-btn
-            button.btn.btn-warning.btn-account-unlink(type='button') Unlink
-            button.btn.btn-default.btn-account-open(type='button') Open
-          |<% } else { %>
-          input.form-control(name='newAccountId', type='text', placeholder='enter account id')
-          div.input-group-btn
-            button.btn.btn-success.btn-account-link(type='button') Link
-          |<% } %>
-        span.help-block <%- errfor.newAccountId %>
 
   script(type='text/template', id='tmpl-password')
     fieldset

--- a/views/admin/users/details.jade
+++ b/views/admin/users/details.jade
@@ -39,6 +39,9 @@ block body
         label Is Site Admin:
         input(type='checkbox', name='siteAdmin')
         span.help-block <%- errfor.siteAdmin %>
+      div.form-group()
+        label Is Active:
+        input(type='checkbox', name='isActive')
       div.form-group(class!='<%- errfor.username ? "has-error" : "" %>')
         label Username:
         input.form-control(type='text', name='username', value!='<%= username %>')

--- a/views/admin/users/details.jade
+++ b/views/admin/users/details.jade
@@ -12,6 +12,7 @@ block body
       div#header
       div#identity
       div#password
+      div#regions
       div#delete
 
   script(type='text/template', id='tmpl-header')
@@ -48,6 +49,23 @@ block body
         span.help-block <%- errfor.email %>
       div.form-group
         button.btn.btn-primary.btn-update(type='button') Update
+
+  script(type='text/template', id='tmpl-region')
+    legend Update Regions
+    div.alerts
+      |<% if (success) { %>
+      div.alert.alert-info.alert-dismissable
+        button.close(type='button', data-dismiss='alert') &times;
+        | Changes have been saved.
+      |<% } %>
+    div#region-rows.form-group
+    div.form-group
+      button.btn.btn-primary.btn-regions(type='button') Update
+
+  script(type='text/template', id='tmpl-region-row')
+    input(type='checkbox', name!='<%= rc_region %>')
+    &nbsp;
+    <%- region_name %>
 
   script(type='text/template', id='tmpl-password')
     fieldset
@@ -92,3 +110,5 @@ block body
         button.btn.btn-danger.btn-delete(type='button') Delete
 
   script(type='text/template', id='data-record') !{data.record}
+  script(type='text/template', id='data-active-regions') !{data.activeRegions}
+  script(type='text/template', id='data-enabled-regions') !{data.enabledRegions}

--- a/views/admin/users/details.jade
+++ b/views/admin/users/details.jade
@@ -34,12 +34,10 @@ block body
           button.close(type='button', data-dismiss='alert') &times;
           | Changes have been saved.
         |<% } %>
-      div.form-group(class!='<%- errfor.isActive ? "has-error" : "" %>')
-        label Is Active:
-        select.form-control(name='isActive')
-          option(value='yes') yes
-          option(value='no') no
-        span.help-block <%- errfor.isActive %>
+      div.form-group(class!='<%- errfor.siteAdmin ? "has-error" : "" %>')
+        label Is Site Admin:
+        input(type='checkbox', name='siteAdmin')
+        span.help-block <%- errfor.siteAdmin %>
       div.form-group(class!='<%- errfor.username ? "has-error" : "" %>')
         label Username:
         input.form-control(type='text', name='username', value!='<%= username %>')

--- a/views/admin/users/index.jade
+++ b/views/admin/users/index.jade
@@ -40,6 +40,7 @@ block body
           th username
           th.stretch email
           th siteAdmin
+          th active
           th id
       tbody#results-rows
 
@@ -49,6 +50,7 @@ block body
     td <%= username %>
     td <%= email %>
     td <%= siteAdmin ? 'Yes' : 'No' %>
+    td <%= isActive %>
     td <%= id %>
 
   script(type='text/template', id='tmpl-results-empty-row')

--- a/views/admin/users/index.jade
+++ b/views/admin/users/index.jade
@@ -7,7 +7,7 @@ block neck
   link(rel='stylesheet', href='/views/admin/users/index.min.css?#{cacheBreaker}')
 
 block feet
-  script(src='/views/admin/users/index.min.js?#{cacheBreaker}')
+  script(src='/views/admin/users/index.js')
 
 block body
   div.row
@@ -77,7 +77,7 @@ block body
     td <%= username %>
     td <%= email %>
     td <%= isActive %>
-    td <%= _id %>
+    td <%= id %>
 
   script(type='text/template', id='tmpl-results-empty-row')
     tr

--- a/views/admin/users/index.jade
+++ b/views/admin/users/index.jade
@@ -31,34 +31,6 @@ block body
         div.col-sm-3
           label Username Search
           input.form-control(name='username', type='text')
-        div.col-sm-3
-          label Can Play Role
-          select.form-control(name='roles')
-            option(value='') any
-            option(value='siteAdmin') siteAdmin
-            option(value='account') account
-        div.col-sm-2
-          label Is Site Admin
-          select.form-control(name='isActive')
-            option(value='') either
-            option(value='yes') yes
-            option(value='no') no
-        div.col-sm-2
-          label Sort By
-          select.form-control(name='sort')
-            option(value='_id') id &#9650;
-            option(value='-_id') id &#9660;
-            option(value='username') username &#9650;
-            option(value='-username') username &#9660;
-            option(value='email') email &#9650;
-            option(value='-email') email &#9660;
-        div.col-sm-2
-          label Results Per Page
-          select.form-control(name='limit')
-            option(value='10') 10 items
-            option(value='20', selected='selected') 20 items
-            option(value='50') 50 items
-            option(value='100') 100 items
 
   script(type='text/template', id='tmpl-results-table')
     table.table.table-striped

--- a/views/admin/users/index.jade
+++ b/views/admin/users/index.jade
@@ -35,10 +35,10 @@ block body
           label Can Play Role
           select.form-control(name='roles')
             option(value='') any
-            option(value='admin') admin
+            option(value='siteAdmin') siteAdmin
             option(value='account') account
         div.col-sm-2
-          label Is Active
+          label Is Site Admin
           select.form-control(name='isActive')
             option(value='') either
             option(value='yes') yes
@@ -67,7 +67,7 @@ block body
           th
           th username
           th.stretch email
-          th active
+          th siteAdmin
           th id
       tbody#results-rows
 
@@ -76,7 +76,7 @@ block body
       input.btn.btn-default.btn-sm.btn-details(type='button', value='Edit')
     td <%= username %>
     td <%= email %>
-    td <%= isActive %>
+    td <%= siteAdmin ? 'Yes' : 'No' %>
     td <%= id %>
 
   script(type='text/template', id='tmpl-results-empty-row')

--- a/views/admin/users/index.js
+++ b/views/admin/users/index.js
@@ -171,6 +171,7 @@ exports.update = function(req, res, next) {
     workflow.on('patchUser', function() {
         var fieldsToSet = {
             siteAdmin: req.body.siteAdmin,
+            isActive: req.body.isActive ? "yes" : "no",
             username: req.body.username,
             email: req.body.email.toLowerCase(),
             search: [

--- a/views/admin/users/index.js
+++ b/views/admin/users/index.js
@@ -8,33 +8,15 @@ exports.find = function(req, res, next) {
 
     var filters = {};
     if (req.query.username) {
-        filters.username = new RegExp('^.*?' + req.query.username + '.*$', 'i');
+        filters.username = { $like: '%' + req.query.username + '%' };
     }
 
-    if (req.query.isActive) {
-        filters.isActive = req.query.isActive;
-    }
-
-    if (req.query.roles && req.query.roles === 'admin') {
-        filters['roles.siteAdmin'] = {
-            $exists: true
-        };
-    }
-
-    if (req.query.roles && req.query.roles === 'account') {
-        filters['roles.account'] = {
-            $exists: true
-        };
-    }
-
-    req.app.db.User.findAll()
+    req.app.db.User.findAll({ where: filters })
         .then(function(results) {
             if (req.xhr) {
                 res.header("Cache-Control", "no-cache, no-store, must-revalidate");
-                results.filters = req.query;
                 res.send(results);
             } else {
-                results.filters = req.query;
                 res.render('admin/users/index', {
                     data: {
                         results: JSON.stringify(results)

--- a/views/admin/users/index.js
+++ b/views/admin/users/index.js
@@ -16,7 +16,7 @@ exports.find = function(req, res, next) {
     }
 
     if (req.query.roles && req.query.roles === 'admin') {
-        filters['roles.admin'] = {
+        filters['roles.siteAdmin'] = {
             $exists: true
         };
     }
@@ -123,8 +123,8 @@ exports.update = function(req, res, next) {
     var workflow = req.app.utility.workflow(req, res);
 
     workflow.on('validate', function() {
-        if (!req.body.isActive) {
-            req.body.isActive = 'no';
+        if (!req.body.siteAdmin) {
+            req.body.siteAdmin = false;
         }
 
         if (!req.body.username) {
@@ -184,7 +184,7 @@ exports.update = function(req, res, next) {
 
     workflow.on('patchUser', function() {
         var fieldsToSet = {
-            isActive: req.body.isActive,
+            siteAdmin: req.body.siteAdmin,
             username: req.body.username,
             email: req.body.email.toLowerCase(),
             search: [

--- a/views/admin/users/index.js
+++ b/views/admin/users/index.js
@@ -83,13 +83,8 @@ exports.create = function(req, res, next) {
     });
 
     workflow.on('duplicateUsernameCheck', function() {
-        req.app.db.models.User.findOne({
-            username: req.body.username
-        }, function(err, user) {
-            if (err) {
-                return workflow.emit('exception', err);
-            }
-
+        req.app.db.User.findOne({ where: { username: req.body.username, }
+        }).then(function(user) {
             if (user) {
                 workflow.outcome.errors.push('That username is already taken.');
                 return workflow.emit('response');
@@ -106,11 +101,8 @@ exports.create = function(req, res, next) {
                 req.body.username
             ]
         };
-        req.app.db.models.User.create(fieldsToSet, function(err, user) {
-            if (err) {
-                return workflow.emit('exception', err);
-            }
-
+        req.app.db.User.create(fieldsToSet)
+        .then(function(user) {
             workflow.outcome.record = user;
             return workflow.emit('response');
         });

--- a/views/admin/users/index.js
+++ b/views/admin/users/index.js
@@ -91,6 +91,7 @@ exports.create = function(req, res, next) {
     workflow.on('createUser', function() {
         var fieldsToSet = {
             username: req.body.username,
+            isActive: "yes",
             search: [
                 req.body.username
             ]

--- a/views/admin/users/index.js
+++ b/views/admin/users/index.js
@@ -285,7 +285,7 @@ exports.password = function(req, res, next) {
     });
 
     workflow.on('patchUser', function() {
-        req.app.db.models.User.encryptPassword(req.body.newPassword, function(err, hash) {
+        req.app.db.User.encryptPassword(req.body.newPassword, function(err, hash) {
             if (err) {
                 return workflow.emit('exception', err);
             }
@@ -293,22 +293,13 @@ exports.password = function(req, res, next) {
             var fieldsToSet = {
                 password: hash
             };
-            req.app.db.models.User.findByIdAndUpdate(req.params.id, fieldsToSet, function(err, user) {
-                if (err) {
-                    return workflow.emit('exception', err);
-                }
-
-                user.populate('roles.admin roles.account', 'name.full', function(err, user) {
-                    if (err) {
-                        return workflow.emit('exception', err);
-                    }
-
-                    workflow.outcome.user = user;
+            req.app.db.User.update(fieldsToSet, {where: {id: req.params.id} })
+                .then(function(numAffected, err) {
+                    workflow.outcome.user = req.params.id;
                     workflow.outcome.newPassword = '';
                     workflow.outcome.confirm = '';
                     workflow.emit('response');
                 });
-            });
         });
     });
 

--- a/views/login/index.js
+++ b/views/login/index.js
@@ -10,7 +10,7 @@ var getReturnUrl = function(req) {
 };
 
 exports.init = function(req, res) {
-    if (req.isAuthenticated()) {
+    if (req.isAuthenticated() && req.user.isActive == 'yes') {
         res.redirect(getReturnUrl(req));
     } else {
         res.render('login/index', {
@@ -98,7 +98,7 @@ exports.login = function(req, res) {
                 return workflow.emit('exception', err);
             }
 
-            if (!user) {
+            if (!user || user.isActive == "no") {
                 var fieldsToSet = {
                     ip: req.ip,
                     user: req.body.username


### PR DESCRIPTION
This adds the user administration interface.  After running the migration, you have to set the use flag to admin on your use to test it, and it will add a new option after logging underneath the requests.

You should be able to add/delete users, change passwords, usernames, deactivate, set admin capability, and set what regions are available for searching for different users.

The commits could probably be squashed/reordered somewhat, but I'll take a second opinion as to how.  I added them in the order that I worked on them.

Fixes #263 and probably #138 except for the default region configuration that has been split out as #264 