### PR TITLE
Fix bug where inactive admins get emailed.

### DIFF
--- a/views/utilities.js
+++ b/views/utilities.js
@@ -419,6 +419,7 @@ module.exports  = {
 
     getContacts: function(region) {
         return db.User.findAll({
+            where: {isActive: "yes"},
             include: [{
                 model: db.activeRegion,
                 where: { rc_region: region.rc_region },


### PR DESCRIPTION
If an admin is a contact for a region, but also marked as inactive, they were still getting emailed.  This is corrected.

Issue #263: Admin users and User Administration screen